### PR TITLE
Fix HypoExponentialDist pdf/ccdf to handle repeated rates

### DIFF
--- a/src/HypoExponentialDist.jl
+++ b/src/HypoExponentialDist.jl
@@ -67,6 +67,10 @@ function Distributions.pdf(d::HypoExponentialDist, x::Real)
     n = length(λ)
     n == 1 && return λ[1] * exp(-λ[1] * x)
 
+    # Partial fractions diverge when any pair of rates coincide; fall back to
+    # the matrix-exponential form in that case.
+    allunique(λ) || return invoke(pdf, Tuple{AbstractPHDist, Real}, d, x)
+
     # Partial fraction expansion (requires distinct rates)
     result = 0.0
     for i in 1:n
@@ -85,6 +89,8 @@ function Distributions.ccdf(d::HypoExponentialDist, x::Real)
     λ = d.rates
     n = length(λ)
     n == 1 && return exp(-λ[1] * x)
+
+    allunique(λ) || return invoke(ccdf, Tuple{AbstractPHDist, Real}, d, x)
 
     # Partial fraction expansion (requires distinct rates)
     result = 0.0

--- a/test/test_subtypes.jl
+++ b/test/test_subtypes.jl
@@ -186,6 +186,35 @@ end
         @test_throws ArgumentError HypoExponentialDist([1.0, -2.0])
         @test_throws ArgumentError HypoExponentialDist(2.0, 1.5)  # SCV must be < 1
     end
+
+    @testset "repeated rates fall back to matrix form" begin
+        # Two equal rates ≡ Erlang(2, λ); pdf/ccdf must not divide by zero.
+        ho_eq = HypoExponentialDist([3.0, 3.0])
+        er = ErlangPHDist(2, 3.0)
+        for x in [0.1, 0.5, 1.0, 2.0]
+            @test pdf(ho_eq, x) ≈ pdf(er, x) atol=1e-10
+            @test ccdf(ho_eq, x) ≈ ccdf(er, x) atol=1e-10
+            @test isfinite(pdf(ho_eq, x))
+            @test isfinite(ccdf(ho_eq, x))
+        end
+        @test mean(ho_eq) ≈ mean(er) atol=1e-10
+        @test var(ho_eq) ≈ var(er) atol=1e-10
+
+        # One distinct rate followed by repeats — the (mean, scv) constructor
+        # produces this shape for scv < 0.5 (e.g. n=4 here).
+        ho_mix = HypoExponentialDist([2.0, 5.0, 5.0, 5.0])
+        ph = PHDist(ho_mix)
+        for x in [0.1, 0.5, 1.0, 2.0]
+            @test pdf(ho_mix, x) ≈ pdf(ph, x) atol=1e-10
+            @test ccdf(ho_mix, x) ≈ ccdf(ph, x) atol=1e-10
+            @test isfinite(pdf(ho_mix, x))
+        end
+
+        # The (mean, scv) constructor with small scv used to NaN; should not now.
+        ho_small = HypoExponentialDist(2.0, 0.3)
+        @test isfinite(pdf(ho_small, 1.0))
+        @test isapprox(mean(ho_small), 2.0; atol=1e-6)
+    end
 end
 
 @testset "ErlangPHDist" begin


### PR DESCRIPTION
## Summary

`HypoExponentialDist`'s `pdf` and `ccdf` use a partial-fraction expansion that divides by `λ[j] - λ[i]`. When two rates coincide that's exactly zero and produces `NaN`/`Inf`. The bug is reachable via the public API: the `HypoExponentialDist(mean, scv)` constructor (HypoExponentialDist.jl:17-24) produces repeated trailing rates whenever `scv < 0.5`.

This PR guards both functions with `allunique(λ)`; on repeats it falls back to the matrix-exponential form inherited from `AbstractPHDist`. Mean, var, mgf, rand, and `kth_moment` already worked correctly with repeats — only the partial-fraction paths needed protection.

## Test plan

Added a `repeated rates fall back to matrix form` testset covering:

- [x] Two equal rates `[3.0, 3.0]` agree with `ErlangPHDist(2, 3.0)` on pdf, ccdf, mean, var.
- [x] Mixed distinct + repeated rates `[2.0, 5.0, 5.0, 5.0]` agree with the equivalent `PHDist(α, T)`.
- [x] `HypoExponentialDist(2.0, 0.3)` (`n=4`, three trailing repeats) produces finite pdf and matches the requested mean — previously `NaN`.

Full test suite: `461/461 pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)