### PR TITLE
Add MAPH marginal survival and right-censored sampling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PhaseTypeDistributions"
 uuid = "c6a3dbec-a81b-4ac0-803e-44f90338b00b"
 authors = ["Zhihao Qiao <zhihao.qiao@uq.edu.au>", "Yoni Nazarathy <y.nazarathy@uq.edu.au>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/README.md
+++ b/README.md
@@ -155,12 +155,31 @@ d = MAPHDist(α, T, D)
 
 pdf(d, 1.0, 1)              # joint sub-density f(1.0, κ=1)
 cdf(d, 1.0, 1)              # P(τ ≤ 1, κ = 1)
+ccdf(d, 1.0)                # all-cause survival S(1.0) = P(τ > 1)
 marginal_absorption(d)      # vector of P(κ = k)
 kth_joint_moment(d, 1, 2)   # E[τ² · 𝟙{κ=1}]
 
 (τ, k) = rand(d)            # sample the pair
 samples = rand(d, 1000)     # vector of (τ, κ) tuples
 ```
+
+### Right-censored sampling
+
+`rand_censored` draws subjects that may be censored before their event, with
+the censoring time either a fixed horizon or a distribution. It returns the
+events and the censoring times separately — the shape the censored-data fitting
+interface of PhaseTypeDistributionsFitting.jl expects:
+
+```julia
+sim = rand_censored(d, 1000, 2.5)          # administrative horizon at u = 2.5
+sim.events                                 # Vector of (τ, κ) for τ ≤ 2.5
+sim.censored                               # censoring times of the rest
+
+rand_censored(d, 1000, Exponential(3.0))   # random censoring times
+```
+
+The censoring time is drawn independently of `(τ, κ)`, so the censoring is
+non-informative. The censored fraction is `ccdf(d, c)` for a fixed horizon `c`.
 
 ### Interface with PH distributions
 

--- a/docs/src/maph.md
+++ b/docs/src/maph.md
@@ -123,6 +123,28 @@ ccdf(d, 1.0, 1)           # P(τ > 1.0, κ = 1)
 `cdf(d, u, k) + ccdf(d, u, k) = π_k` for all `u ≥ 0`. As `u → ∞`,
 `cdf(d, u, k) → π_k` and `ccdf(d, u, k) → 0`.
 
+### Marginal (all-cause) law of `τ`
+
+Dropping the cause index gives the marginal law of the absorption time. The
+survival `S(u) = P(τ > u) = α' exp(Tu) 1` is the likelihood of a record known
+only to have survived past `u` — a **right-censored** observation, whose
+eventual cause is unobserved:
+
+```@example maph
+ccdf(d, 1.0)              # S(1.0) = P(τ > 1.0)
+```
+
+```@example maph
+cdf(d, 1.0), logccdf(d, 1.0)
+```
+
+It sums the joint survivals over causes, and coincides with the marginal PH law
+of `τ` (see [Bridge to PH](#Bridge-to-PH)):
+
+```@example maph
+ccdf(d, 1.0) ≈ sum(ccdf(d, 1.0, k) for k in 1:nabsorbing(d)) ≈ ccdf(PHDist(d), 1.0)
+```
+
 ### Absorption probabilities
 
 `R[i, k] = P(κ = k | start in phase i) = (-T⁻¹D)[i, k]`. Rows sum to 1 for
@@ -178,6 +200,29 @@ sims = rand(rng, d, n)
 [sum(s -> s[2] == k, sims) / n for k in 1:nabsorbing(d)]
 ```
 
+### Right-censored sampling
+
+`rand_censored` draws subjects that may be right-censored before their event.
+The censoring argument is either a fixed administrative horizon or a
+distribution for the per-subject censoring time; either way it is drawn
+independently of `(τ, κ)`, so the censoring is non-informative:
+
+```@example maph
+sim = rand_censored(rng, d, 5_000, 0.4)     # horizon at u = 0.4
+length(sim.events), length(sim.censored)
+```
+
+The censored fraction matches the survival at the horizon:
+
+```@example maph
+length(sim.censored) / 5_000, ccdf(d, 0.4)
+```
+
+The returned `(events, censored)` pair is shaped to feed the censored-data
+fitting interface of
+[PhaseTypeDistributionsFitting.jl](https://julia-matrix-analytic-probability.github.io/PhaseTypeDistributionsFitting.jl/)
+directly, as `fit_mle(MAPHDist, sim.events; m = 3, censored = sim.censored)`.
+
 ## Bridge to PH
 
 Every MAPH has a marginal `τ`, which is a PH distribution:
@@ -220,5 +265,9 @@ conditional_time
 Distributions.cdf(::MAPHDist, ::Real, ::Integer)
 Distributions.ccdf(::MAPHDist, ::Real, ::Integer)
 Distributions.pdf(::MAPHDist, ::Real, ::Integer)
+Distributions.cdf(::MAPHDist, ::Real)
+Distributions.ccdf(::MAPHDist, ::Real)
+Distributions.logccdf(::MAPHDist, ::Real)
 Base.rand(::Random.AbstractRNG, ::MAPHDist)
+rand_censored
 ```

--- a/src/MAPHDist.jl
+++ b/src/MAPHDist.jl
@@ -165,6 +165,45 @@ function Distributions.ccdf(d::MAPHDist, u::Real, k::Integer)
     return marginal_absorption(d)[k] - cdf(d, u, k)
 end
 
+# ---- Marginal (all-cause) law of τ ----
+# S(u) = P(τ > u) = α' exp(Tu) 1 is the likelihood contribution of a record known
+# only to be right-censored at u — the eventual cause is unobserved. As with
+# `AbstractPHDist`, the survival is the natively-computed quantity and the cdf
+# derives from it, so tail precision is preserved.
+
+"""
+    ccdf(d::MAPHDist, u::Real)
+
+Marginal (all-cause) survival `S(u) = P(τ > u) = α' exp(T·u) 1`, the likelihood of
+an observation known only to be right-censored at `u`. Equals `Σₖ ccdf(d, u, k)`
+and agrees with `ccdf(PHDist(d), u)`.
+"""
+function Distributions.ccdf(d::MAPHDist, u::Real)
+    u <= 0 && return 1.0
+    return d.α' * exp(d.T * u) * ones(nphases(d))
+end
+
+"""
+    cdf(d::MAPHDist, u::Real)
+
+Marginal (all-cause) distribution function `P(τ ≤ u) = 1 - S(u)`.
+"""
+function Distributions.cdf(d::MAPHDist, u::Real)
+    u < 0 && return 0.0
+    return 1.0 - ccdf(d, u)
+end
+
+"""
+    logccdf(d::MAPHDist, u::Real)
+
+Log marginal survival `log P(τ > u)`, the log-likelihood contribution of a record
+right-censored at `u`. Returns `-Inf` when the survival underflows to zero.
+"""
+function Distributions.logccdf(d::MAPHDist, u::Real)
+    s = ccdf(d, u)
+    return s > 0 ? log(s) : -Inf
+end
+
 function _sample_categorical(rng::AbstractRNG, p::AbstractVector)
     u = rand(rng)
     cum = 0.0
@@ -224,6 +263,50 @@ end
 Random.rand(d::MAPHDist) = rand(Random.default_rng(), d)
 Random.rand(rng::AbstractRNG, d::MAPHDist, n::Integer) = [rand(rng, d) for _ in 1:n]
 Random.rand(d::MAPHDist, n::Integer) = rand(Random.default_rng(), d, n)
+
+# Draw one censoring time: either a fixed administrative horizon or a variate of
+# a censoring distribution independent of (τ, κ).
+_draw_censoring(::AbstractRNG, c::Real) = Float64(c)
+_draw_censoring(rng::AbstractRNG, c::UnivariateDistribution) = Float64(rand(rng, c))
+
+"""
+    rand_censored([rng,] d::MAPHDist, L::Integer, censoring)
+
+Draw `L` independently right-censored competing-risks records. For each subject a
+pair `(τ, κ)` is drawn from `d` and a censoring time `C` from `censoring` — either
+a `Real` (a fixed administrative horizon) or a `UnivariateDistribution` — and the
+subject is recorded as an event when `τ ≤ C` and as censored at `C` otherwise.
+
+Returns the named tuple `(events, censored)`, where `events` is a vector of
+`(τ, κ)` pairs and `censored` a vector of censoring times, shaped to feed the
+fitting interface of PhaseTypeDistributionsFitting.jl directly:
+
+```julia
+sim = rand_censored(d, 1000, Exponential(2.0))
+fit_mle(MAPHDist, sim.events; m = 3, censored = sim.censored)
+```
+
+Because `C` is drawn independently of `(τ, κ)`, the censoring is non-informative,
+as the censored-data EM assumes.
+"""
+function rand_censored(rng::AbstractRNG, d::MAPHDist, L::Integer, censoring)
+    L >= 0 || throw(ArgumentError("L must be non-negative, got $L"))
+    if censoring isa Real
+        censoring > 0 || throw(ArgumentError("censoring time must be positive, got $censoring"))
+    end
+    events = Tuple{Float64, Int}[]
+    censored = Float64[]
+    for _ in 1:L
+        τ, κ = rand(rng, d)
+        c = _draw_censoring(rng, censoring)
+        c > 0 || throw(ArgumentError("censoring times must be strictly positive, got $c"))
+        τ <= c ? push!(events, (τ, κ)) : push!(censored, c)
+    end
+    return (events = events, censored = censored)
+end
+
+rand_censored(d::MAPHDist, L::Integer, censoring) =
+    rand_censored(Random.default_rng(), d, L, censoring)
 
 # ---- Moments ----
 

--- a/src/PhaseTypeDistributions.jl
+++ b/src/PhaseTypeDistributions.jl
@@ -5,7 +5,7 @@ using Random
 using Statistics
 using Distributions
 using FixedSparsityMatrices
-import Distributions: pdf, logpdf, cdf, ccdf, insupport, minimum, maximum,
+import Distributions: pdf, logpdf, cdf, ccdf, logccdf, insupport, minimum, maximum,
     quantile, params, skewness, kurtosis, mgf
 import Random: rand
 import Statistics: mean, var
@@ -42,7 +42,7 @@ export exit_rate_matrix, nabsorbing, absorption_probs, marginal_absorption
 export scv, kth_moment
 
 # MAPH-specific functions
-export kth_joint_moment, conditional_time
+export kth_joint_moment, conditional_time, rand_censored
 
 # Comparison helpers
 export moments_isapprox, distribution_isapprox, moment_vector

--- a/test/test_maph.jl
+++ b/test/test_maph.jl
@@ -86,6 +86,61 @@
         @test ccdf(d, 0.0, 1) ≈ π[1] atol=1e-10
     end
 
+    @testset "marginal survival S(u) = P(τ > u)" begin
+        for u in [0.05, 0.5, 1.0, 3.0, 10.0]
+            S = ccdf(d, u)
+            # All-cause survival is the sum of the joint survivals ...
+            @test S ≈ sum(ccdf(d, u, k) for k in 1:2) atol=1e-12
+            # ... and agrees with the marginal PH law of τ.
+            @test S ≈ ccdf(PHDist(d), u) atol=1e-12
+            @test cdf(d, u) + S ≈ 1.0 atol=1e-12
+            @test logccdf(d, u) ≈ log(S) atol=1e-12
+        end
+        @test ccdf(d, 0.0) == 1.0
+        @test ccdf(d, -1.0) == 1.0
+        @test cdf(d, -1.0) == 0.0
+        @test cdf(d, 0.0) == 0.0
+        @test ccdf(d, 1e4) ≈ 0.0 atol=1e-12
+        @test logccdf(d, 1e4) == -Inf
+    end
+
+    @testset "rand_censored" begin
+        rng = StableRNG(4242)
+        N = 20_000
+
+        # Fixed administrative horizon: the censored fraction is S(c).
+        c = 0.4
+        sim = rand_censored(rng, d, N, c)
+        @test length(sim.events) + length(sim.censored) == N
+        @test all(==(c), sim.censored)
+        @test all(e -> 0 < e[1] <= c && 1 <= e[2] <= 2, sim.events)
+        @test isapprox(length(sim.censored) / N, ccdf(d, c); atol=0.02)
+        # Events are the sub-distribution restricted to (0, c]: their cause split
+        # is F(c, k) / F(c) and their count is F(c)·N.
+        @test isapprox(length(sim.events) / N, cdf(d, c); atol=0.02)
+        for k in 1:2
+            frac = count(e -> e[2] == k, sim.events) / length(sim.events)
+            @test isapprox(frac, cdf(d, c, k) / cdf(d, c); atol=0.02)
+        end
+
+        # Random censoring times: P(censored) = P(τ > C) with C ⊥ (τ, κ).
+        cdist = Exponential(1.0)
+        sim2 = rand_censored(rng, d, N, cdist)
+        @test length(sim2.events) + length(sim2.censored) == N
+        @test all(>(0), sim2.censored)
+        grid = range(0.0, 40.0; length=20_000)
+        h = step(grid)
+        p_cens = sum(ccdf(d, u) * pdf(cdist, u) for u in grid) * h
+        @test isapprox(length(sim2.censored) / N, p_cens; atol=0.02)
+
+        # No censoring at all when the horizon is far beyond the support.
+        sim3 = rand_censored(rng, d, 200, 1e6)
+        @test isempty(sim3.censored) && length(sim3.events) == 200
+
+        @test_throws ArgumentError rand_censored(rng, d, 10, 0.0)
+        @test_throws ArgumentError rand_censored(rng, d, -1, 1.0)
+    end
+
     @testset "kth_joint_moment" begin
         # First moment E[τ · 𝟙{κ=k}] = α T⁻² D_k
         for k in 1:2


### PR DESCRIPTION
Support needed by the right-censored MAPH fitting in [PhaseTypeDistributionsFitting.jl](https://github.com/Julia-Matrix-Analytic-Probability/PhaseTypeDistributionsFitting.jl) — see the companion PR there.

### Marginal (all-cause) law of τ

`ccdf(d::MAPHDist, u)` gives the survival `S(u) = α' exp(Tu) 1`, which is exactly the likelihood contribution of a record known only to have survived past `u`. Only the joint `(u, k)` versions existed before, so this had to be reached indirectly through `PHDist(d)`. `cdf(d, u)` and `logccdf(d, u)` come with it.

```julia
ccdf(d, 1.0)                                       # S(1.0) = P(τ > 1.0)
ccdf(d, 1.0) ≈ sum(ccdf(d, 1.0, k) for k in 1:n)   # sums the joint survivals
ccdf(d, 1.0) ≈ ccdf(PHDist(d), 1.0)                # agrees with the marginal PH
```

### Right-censored sampling

`rand_censored(d, L, censoring)` draws `L` subjects that may be censored before their event. The censoring argument is either a fixed administrative horizon or a distribution; either way it is drawn independently of `(τ, κ)`, so the censoring is non-informative. It returns `(events, censored)` — the shape the censored fitting interface consumes:

```julia
sim = rand_censored(d, 1000, 2.5)
fit_mle(MAPHDist, sim.events; m = 3, censored = sim.censored)
```

### Notes

- Additive only; nothing existing changes behaviour. Version bumped to 0.2.1.
- Tests: 572 passing. New coverage checks the survival against the joint survivals and the marginal PH, and `rand_censored`'s censored fraction against `ccdf(d, c)` for a fixed horizon and against `∫ S(u) f_C(u) du` for random censoring.
- Docs: new section in `docs/src/maph.md` plus README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uvffpeP6sC3jQaap95ziG